### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleBoundaryValueDiffEq"
 uuid = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -24,7 +24,7 @@ Pkg = "1.10"
 PrecompileTools = "1.2.1"
 Reexport = "1.2.2"
 SafeTestsets = "0.1"
-SciMLBase = "2.30.3"
+SciMLBase = "2.30.3, 3"
 SimpleNonlinearSolve = "1.6.0,2 "
 Test = "1.10"
 julia = "1.10"


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3
- Bump package version (minor): 1.2.0 → 1.3.0
- No code changes needed - package doesn't use deprecated SciMLBase v2 patterns
- Supersedes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)