### PR TITLE
Bump for SciMLBase v3 / DiffEqBase v7 / OrdinaryDiffEq v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleBoundaryValueDiffEq"
 uuid = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -15,11 +15,11 @@ SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 [compat]
 Aqua = "0.8"
 BVProblemLibrary = "0.1.5"
-DiffEqBase = "6.148.0"
-DiffEqDevTools = "2.44.2"
+DiffEqBase = "6.148.0, 7"
+DiffEqDevTools = "2.44.2, 3"
 FiniteDiff = "2.24.0"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqTsit5 = "1.1.0"
+OrdinaryDiffEqTsit5 = "1.1.0, 2"
 Pkg = "1.10"
 PrecompileTools = "1.2.1"
 Reexport = "1.2.2"


### PR DESCRIPTION
## Summary

Bumps compat to accept the v7 OrdinaryDiffEq stack (**DiffEqBase v7**, **OrdinaryDiffEqTsit5 v2**) along with **SciMLBase v3** (already present) and **DiffEqDevTools v3**. Supersedes #43, which only widened the dependabot lower bounds.

- Version: `1.3.0` → `1.4.0` (minor bump to signal the widened compat window)
- `DiffEqBase = "6.148.0, 7"`
- `DiffEqDevTools = "2.44.2, 3"` (test-only)
- `OrdinaryDiffEqTsit5 = "1.1.0, 2"`
- `SciMLBase = "2.30.3, 3"` (unchanged; already v3-capable)

## Migrations applied: compat bump only

A full audit of `src/` and `test/` against the v7 migration guide (RAT v4 indexing, SciMLBase v3 renames, OrdinaryDiffEq v7 kwarg/typed-object changes, DiffEqBase v7 removals, ensemble signature, removed `construct*` tableaus, etc.) surfaced **no code-level breakages**. The package only touches:

- The default-solver `Tsit5` via the `OrdinaryDiffEqTsit5` sublibrary (already the v7 layout)
- `SciMLBase.AbstractBVPAlgorithm` (already the `Abstract*` form — no `DEAlgorithm` rename needed)
- ODESolution access via `sol.u`, `sol.t`, `sol(t)` interpolation, `sol.retcode`, `sol.resid` — none of which are affected by the RAT v4 `AbstractArray`-subtyping change
- No `u_modified!`, `has_destats`/`sol.destats`, `construct*` tableaus, `QuadratureProblem`, `symbol_to_ReturnCode`, `syms`/`paramsyms`/`indepsym`, `prob.lb`/`prob.ub`, `EnsembleProblem(vec_of_probs)`, `prob_func(prob,i,repeat)`, `output_func(sol,i)`, `autodiff=Bool`, `verbose=Bool`, `alias_u0`/`alias_du0`, `lazy=Bool`, `chunk_size`/`diff_type`/`standardtag`/`precs`, `gamma`/`beta1`/`beta2`/`qmin`/`qmax`/`qsteady*`/`qoldinit`, `integrator.EEst`, `Static.True`/`Static.False`, `williamson_condition`, `RECOMPILE_BY_DEFAULT`, `concrete_solve`, `fastpow`, or integer-indexing on an ODESolution anywhere

## Test plan

- [x] `Pkg.test()` against the v7 stack (DiffEqBase v7.0.0, SciMLBase v3.5.0, RecursiveArrayTools v4.2.0, OrdinaryDiffEqCore v4.0.0, OrdinaryDiffEqTsit5#master):
  - Aqua: **9/9**
  - MIRK convergence: **15/15**
  - Shooting convergence: **6/8** — the 2 failing cases (`bvp1`, `bvp3`, iip branch) return `norm(sol.resid, Inf) = 3.4e-4`, violating the `< 1e-8` assertion
  - JET: **1/1**
- [x] The 2 shooting failures are a **pre-existing latent bug on `main@1.3.0`**, not a regression: they reproduce identically (exact same residual `0.0003427869754834001`) against the **old v6/v2 stack** when `Pkg.test()`'s default `--check-bounds=yes` is enabled. Running the same tests on the new stack without `--check-bounds=yes` passes 23/23. The iip `SimpleShooting` loss closure appears to have a stale-buffer issue that shows up only under bounds-checking — orthogonal to this compat bump and out of scope for this PR.

## Supersedes

- #43 (dependabot compat-only bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)