### PR TITLE
Fix SimpleShooting: propagate tolerances to internal ODE cache

### DIFF
--- a/src/single_shooting.jl
+++ b/src/single_shooting.jl
@@ -18,7 +18,9 @@ function DiffEqBase.solve(
     iip = isinplace(prob)
 
     internal_prob = ODEProblem{iip}(prob.f, u0, prob.tspan, prob.p)
-    ode_cache = SciMLBase.__init(internal_prob, alg.ode_alg)
+    ode_cache = SciMLBase.__init(
+        internal_prob, alg.ode_alg; abstol = abstol, reltol = reltol, odesolve_kwargs...
+    )
 
     loss = if iip
         function (resid, u, p)


### PR DESCRIPTION
## Summary

Fixes the `bvp1` / `bvp3` residual failures in `test/shooting_tests.jl` (`norm(sol.resid, Inf) = 3.43e-4` vs. required `< 1e-8`). These were observed on `main` after #44 and, as further investigation showed, are a pre-existing bug on `main` — but the diagnosis given in #44 ("stale-buffer issue under `--check-bounds=yes`") was incorrect. The real cause is a tolerance mismatch.

## Root cause

In `src/single_shooting.jl` the internal ODE integrator used by the Newton loss closure was initialized without tolerances:

```julia
ode_cache = SciMLBase.__init(internal_prob, alg.ode_alg)
```

So every loss evaluation during `SimpleNewtonRaphson` ran with Tsit5's defaults (`abstol=1e-6`, `reltol=1e-3`), regardless of what the user passed to `solve(bvp, SimpleShooting(); abstol, reltol, ...)`.

On the test problem `u'' = -u` over `tspan=(0, 100)`:

- Loose-tol solve from `u0 = [0, -1.9748576]` gives `u(100)[1] = 0.9996572` (~3.4e-4 error)
- Tight-tol solve from the same `u0` gives `u(100)[1] = 1.0074022`

The Newton iteration minimizes the *noisy* residual and converges to `u0 = [0.0, -1.989475871201687]` — a shallow local minimum of the loose-tolerance loss, not a root of the tight-tolerance residual. The reported `sol.resid = 3.43e-4` then fails the `< 1e-8` assertion.

`--check-bounds=yes` changes the magnitude (3.4e-4 iip vs 2.4e-6 iip vs 1.2e-9 oop) because LLVM inbounds optimizations get disabled → different FP reassociation → different noise realization → different local minimum. Same bug, different settling points. Notably the iip cases fail `< 1e-8` **even without** `--check-bounds=yes` (2.36e-6 > 1e-8), contrary to the claim in #44's description.

## Fix

Forward `abstol`, `reltol`, and `odesolve_kwargs` into `SciMLBase.__init` so loss evaluations honor the user-requested precision:

```julia
ode_cache = SciMLBase.__init(
    internal_prob, alg.ode_alg; abstol = abstol, reltol = reltol, odesolve_kwargs...
)
```

## Verification

Local reproduction on the CI stack (`DiffEqBase v6.218.0`, `SciMLBase v2.155.1`, `OrdinaryDiffEqTsit5 v1.12.0`, Julia 1.10.11) under `--check-bounds=yes`:

| | `norm(sol.resid, Inf)` before | after |
|---|---|---|
| bvp1 (iip, `BVProblem`) | 3.43e-4 ❌ | 2.05e-11 ✅ |
| bvp2 (oop, `BVProblem`) | 1.20e-9 ✅ | 2.74e-12 ✅ |
| bvp3 (iip, `TwoPointBVProblem`) | 3.43e-4 ❌ | 2.05e-11 ✅ |
| bvp4 (oop, `TwoPointBVProblem`) | 1.20e-9 ✅ | 2.74e-12 ✅ |

`Pkg.test()` (which uses `--check-bounds=yes` by default) now reports **33/33 passing** locally.

## Test plan

- [x] `Pkg.test()` on Julia 1.10 — 33/33 pass
- [x] Explicit `--check-bounds=yes` run of `test/shooting_tests.jl` — 8/8 pass
- [ ] CI across Julia lts / 1 / pre on ubuntu / macOS / windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)