### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -17,30 +17,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
 
-env:
-  RETESTITEMS_NWORKERS: 4
-  RETESTITEMS_NWORKERS_THREADS: 2
-
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - "Core"
-          - "NoPre"
-        os:
-          - "ubuntu-latest"
-          - "macOS-latest"
-          - "windows-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
-      os: "${{ matrix.os }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,7 @@
+[Core]
+versions = ["1", "lts", "pre"]
+os = ["ubuntu-latest", "macOS-latest", "windows-latest"]
+
+[NoPre]
+versions = ["1", "lts", "pre"]
+os = ["ubuntu-latest", "macOS-latest", "windows-latest"]


### PR DESCRIPTION
## Summary

Converts the root **Tests.yml** test workflow to the canonical thin caller
`SciML/.github/.github/workflows/grouped-tests.yml@v1`, with its
group × version × OS matrix declared once in a root **test/test_groups.toml**.

`Tests.yml`'s job block is replaced by:

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    secrets: "inherit"
```

The filename (`Tests.yml`) and `name: "Tests"` are kept so the branch-protection
status check is preserved. `on:` triggers and `concurrency:` are kept verbatim.
The dead workflow-level `env:` block (`RETESTITEMS_*`, never consumed by the
reusable-workflow call) is dropped. No other workflow files are touched.

## test/test_groups.toml

```toml
[Core]
versions = ["1", "lts", "pre"]
os = ["ubuntu-latest", "macOS-latest", "windows-latest"]

[NoPre]
versions = ["1", "lts", "pre"]
os = ["ubuntu-latest", "macOS-latest", "windows-latest"]
```

`runtests.jl` already dispatches on the standard `GROUP` env var and already
no-ops the `NoPre` (JET) group on prereleases, so **no runtests.jl change** is
needed and no `with:` overrides are required (defaults `check-bounds: yes`,
`coverage: true`, `coverage-directories: src,ext`, `GROUP` env name all match
the old behaviour; the package has no `ext/`).

## Matrix match

Old hand-maintained matrix = `version=[1,lts,pre] × group=[Core,NoPre] ×
os=[ubuntu-latest,macOS-latest,windows-latest]` = **18 cells**, no excludes.

Verified with `compute_affected_sublibraries.jl . --root-matrix` (SciML/.github@v1):
emits 18 entries, exact set equality against the old matrix — **18/18 exact**.
TOML and YAML both parse cleanly.

## QA

Category A (Core/QA GROUP dispatch already present via `aqua_tests.jl` in Core
and JET in `NoPre`). Static matrix verification only; no Aqua/JET run locally,
no source changes, no test exclusions added.

Ignore until reviewed by @ChrisRackauckas.