### PR TITLE
Canonicalize test units to @safetestset

### DIFF
--- a/test/aqua_tests.jl
+++ b/test/aqua_tests.jl
@@ -1,6 +1,6 @@
-@testset "Aqua" begin
-    using SimpleBoundaryValueDiffEq, Aqua
+using SimpleBoundaryValueDiffEq, Aqua, Test
 
+@testset "Aqua" begin
     if isdefined(Base, :precompile_all)
         Aqua.find_persistent_tasks_deps(SimpleBoundaryValueDiffEq)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,14 +8,14 @@ const GROUP = get(ENV, "GROUP", "All")
 
 @testset "SimpleBoundaryValueDiffEq.jl" begin
     if GROUP == "All" || GROUP == "Core"
-        @testset "Code quality (Aqua.jl)" begin
+        @safetestset "Code quality (Aqua.jl)" begin
             include("aqua_tests.jl")
         end
-        @testset "Test MIRK methods convergence" begin
+        @safetestset "Test MIRK methods convergence" begin
             include("mirk_tests.jl")
         end
 
-        @testset "Test Shooting methods convergence" begin
+        @safetestset "Test Shooting methods convergence" begin
             include("shooting_tests.jl")
         end
     end
@@ -25,7 +25,7 @@ const GROUP = get(ENV, "GROUP", "All")
         Pkg.activate("nopre")
         Pkg.develop(Pkg.PackageSpec(path = dirname(@__DIR__)))
         Pkg.instantiate()
-        @testset "Code linting (JET.jl)" begin
+        @safetestset "Code linting (JET.jl)" begin
             include("nopre/jet_tests.jl")
         end
     end


### PR DESCRIPTION
Converts the independent top-level test units to `@safetestset` so each runs in its own fresh module, matching the canonical OrdinaryDiffEq structure (test isolation + world-age safety).

## Changes
- `test/runtests.jl`: the four independent units (`Code quality (Aqua.jl)`, `Test MIRK methods convergence`, `Test Shooting methods convergence`, `Code linting (JET.jl)`) changed from plain `@testset "X" begin include(...) end` to `@safetestset "X" begin include(...) end`. The outer grouping `@testset "SimpleBoundaryValueDiffEq.jl"` wrapper is preserved (`@safetestset` nests cleanly inside it).
- `test/aqua_tests.jl`: hoisted the `using SimpleBoundaryValueDiffEq, Aqua` block to the file top level (added `Test`) so the included file is self-contained inside its fresh module. The inner `@testset "Aqua"` is kept as a nested grouping testset.

The other included files (`mirk_tests.jl`, `shooting_tests.jl`, `nopre/jet_tests.jl`) already had their `using` lines at file top level, so they are already self-contained as `@safetestset` bodies.

## Behavior-preserving
- No change to the GROUP dispatch ladder (Core / NoPre), which tests run under which group, or any assertions.
- `SafeTestsets` was already a test dependency (`[extras]` + `[targets].test` + `[compat]`) and `using SafeTestsets` was already imported in `runtests.jl`.

## Verification
Ran `GROUP=Core` locally on Julia 1.11: all 32 tests pass under the converted structure.

```
Test Summary:                | Pass  Total     Time
SimpleBoundaryValueDiffEq.jl |   32     32  1m09.2s
     Testing SimpleBoundaryValueDiffEq tests passed
```

Ignore until reviewed by @ChrisRackauckas.
