### PR TITLE
Release prep: bump version to 1.4.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleBoundaryValueDiffEq"
 uuid = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.4.2"
+version = "1.4.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
## Summary

Bumps `version` in Project.toml from `1.4.2` to `1.4.3` to register the changes that have accumulated since the last release (commit `f33bdd3`, "Release v1.4.2"), whose tree-sha1 matches the currently registered `1.4.2` in JuliaRegistries/General.

## Changes since v1.4.2 (single squashed commit, #58 "Add SciMLTesting 2.1 QA docs coverage")

- Added docstrings for `SimpleMIRK4`, `SimpleMIRK5`, `SimpleMIRK6`, and `SimpleShooting`.
- Refactored `using X` statements to explicit `using X: a, b` / `import X: y` per the new SciMLTesting `explicit_imports = true` QA check.
- Added `CommonSolve` as an explicit direct dependency (compat `"0.2"`) — `solve!` was already being called in `single_shooting.jl` but was previously only reachable implicitly through `using DiffEqBase`'s re-export; this makes the dependency explicit without changing any runtime behavior.
- Bumped `SciMLTesting` compat from `"1"` to `"2.1"` (test-only `[extras]`/`[targets]` dependency, not part of the runtime dependency graph) and added a new `QA` test group (`test/qa/`) running Aqua + JET + explicit-imports checks.

## Bump type: PATCH (1.4.2 → 1.4.3)

No new exported symbols, no behavior change, and no breaking change. The diff is entirely QA/docs/test infrastructure plus an internal "make an existing implicit dependency explicit" fix, so this defaults to a PATCH bump per the release-prep classification.

## Compat bounds

Left untouched except for what's already in the diff (`CommonSolve = "0.2"`, `SciMLTesting = "2.1"`, both added/changed by the PR being released, not by this bump PR). `CommonSolve = "0.2"` is correct as a lower bound: `solve!` has been part of `CommonSolve` since its earliest 0.2.x releases, and the current latest registered version is `0.2.11`, so no wider bound is needed. `SciMLTesting` is test-only and doesn't affect downstream consumers' resolution.