### PR TITLE
Add rendered public API docs QA

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SimpleBoundaryValueDiffEq = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
+
+[compat]
+Documenter = "1"
+SimpleBoundaryValueDiffEq = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,24 @@
+using Documenter
+using SimpleBoundaryValueDiffEq
+
+DocMeta.setdocmeta!(
+    SimpleBoundaryValueDiffEq,
+    :DocTestSetup,
+    :(using SimpleBoundaryValueDiffEq);
+    recursive = true,
+)
+
+makedocs(;
+    modules = [SimpleBoundaryValueDiffEq],
+    sitename = "SimpleBoundaryValueDiffEq.jl",
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://docs.sciml.ai/SimpleBoundaryValueDiffEq/stable/",
+        assets = String[],
+    ),
+    pages = [
+        "Home" => "index.md",
+    ],
+    checkdocs = :exports,
+    warnonly = false,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,13 @@
+# SimpleBoundaryValueDiffEq.jl
+
+SimpleBoundaryValueDiffEq.jl provides lightweight boundary value problem
+algorithms for the SciML common solve interface.
+
+## Algorithms
+
+```@docs
+SimpleMIRK4
+SimpleMIRK5
+SimpleMIRK6
+SimpleShooting
+```

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,19 @@
 using SciMLTesting, SimpleBoundaryValueDiffEq, JET
 
+function binding_owner(pkg::Module, name::Symbol)
+    value = getfield(pkg, name)
+    return value isa Module ? value : parentmodule(value)
+end
+
+# Only dependency-owned reexports are skipped from rendered-docs coverage.
+const DEPENDENCY_REEXPORTS = Tuple(
+    name for name in public_api_names(SimpleBoundaryValueDiffEq)
+        if isdefined(SimpleBoundaryValueDiffEq, name) &&
+        binding_owner(SimpleBoundaryValueDiffEq, name) !== SimpleBoundaryValueDiffEq
+)
+
 run_qa(
     SimpleBoundaryValueDiffEq;
     explicit_imports = true,
+    api_docs_kwargs = (; rendered = true, rendered_ignore = DEPENDENCY_REEXPORTS),
 )


### PR DESCRIPTION
This PR updates the public API documentation QA for the owned SimpleBoundaryValueDiffEq API.

Ignore this PR until reviewed by @ChrisRackauckas.

Changes:
- Add a minimal Documenter manual that renders the package-owned algorithm exports.
- Enable SciMLTesting rendered public API docs QA with `api_docs_kwargs = (; rendered = true, rendered_ignore = DEPENDENCY_REEXPORTS)`.
- Ignore only dependency-owned reexports for rendered-docs coverage.
- Ignore generated docs build output and docs manifests.

Validation run locally with Julia 1.10.11:
- `git diff --check` passed.
- `Runic.main(["--check", "test/qa/qa.jl", "docs/make.jl"])` passed.
- Direct QA passed: `Quality Assurance | 18  18  42.4s`.
- Docs build passed: Documenter completed through `HTMLWriter: rendering HTML pages`.
- `GROUP=QA Pkg.test()` passed: `Quality Assurance | 18  18  43.4s`; `SimpleBoundaryValueDiffEq tests passed`.
