### PR TITLE
Use inherited public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,19 +1,6 @@
 using SciMLTesting, SimpleBoundaryValueDiffEq, JET
 
-function binding_owner(pkg::Module, name::Symbol)
-    value = getfield(pkg, name)
-    return value isa Module ? value : parentmodule(value)
-end
-
-# Only dependency-owned reexports are skipped from rendered-docs coverage.
-const DEPENDENCY_REEXPORTS = Tuple(
-    name for name in public_api_names(SimpleBoundaryValueDiffEq)
-        if isdefined(SimpleBoundaryValueDiffEq, name) &&
-        binding_owner(SimpleBoundaryValueDiffEq, name) !== SimpleBoundaryValueDiffEq
-)
-
 run_qa(
     SimpleBoundaryValueDiffEq;
     explicit_imports = true,
-    api_docs_kwargs = (; rendered = true, rendered_ignore = DEPENDENCY_REEXPORTS),
 )

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,5 +2,4 @@ using SciMLTesting, SimpleBoundaryValueDiffEq, JET
 
 run_qa(
     SimpleBoundaryValueDiffEq;
-    explicit_imports = true,
 )

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,3 @@
 using SciMLTesting, SimpleBoundaryValueDiffEq, JET
 
-run_qa(
-    SimpleBoundaryValueDiffEq;
-)
+run_qa(SimpleBoundaryValueDiffEq)


### PR DESCRIPTION
Removes the package-specific public API documentation ignore list. Locally defined algorithms already have rendered SciMLStyle docstrings; inherited SciMLBase API is verified at its defining package by SciMLTesting #27.

Depends on https://github.com/SciML/SciMLTesting.jl/pull/27.

Ignore until reviewed by @ChrisRackauckas.