### PR TITLE
Adopt strict public API QA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleBoundaryValueDiffEq"
 uuid = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.4.3"
+version = "2.0.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -9,7 +9,6 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 
@@ -23,10 +22,9 @@ FiniteDiff = "2.24.0"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqTsit5 = "1.1.0, 2"
 PrecompileTools = "1.2.1"
-Reexport = "1.2.2"
 SafeTestsets = "0.1, 1"
 SciMLBase = "2.49.0, 3"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 SimpleNonlinearSolve = "1.6.0,2 "
 Test = "1.10"
 julia = "1.10"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,5 +4,5 @@ SimpleBoundaryValueDiffEq = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
 
 [compat]
 Documenter = "1"
-SimpleBoundaryValueDiffEq = "1"
+SimpleBoundaryValueDiffEq = "2"
 julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using SimpleBoundaryValueDiffEq
 DocMeta.setdocmeta!(
     SimpleBoundaryValueDiffEq,
     :DocTestSetup,
-    :(using SimpleBoundaryValueDiffEq);
+    :(using SimpleBoundaryValueDiffEq; using SciMLBase: solve);
     recursive = true,
 )
 
@@ -18,6 +18,7 @@ makedocs(;
     ),
     pages = [
         "Home" => "index.md",
+        "Developer API" => "developer_api.md",
     ],
     checkdocs = :exports,
     warnonly = false,

--- a/docs/src/developer_api.md
+++ b/docs/src/developer_api.md
@@ -1,0 +1,13 @@
+# Developer API
+
+`AbstractSimpleMIRK` is the package's documented extension interface. It is intended for
+solver developers, not ordinary problem-solving workflows. Subtypes must implement all required
+tableau methods below; the package's generic `solve` method handles both in-place and
+out-of-place `BVProblem`s.
+
+```@docs
+AbstractSimpleMIRK
+alg_order
+alg_stage
+constructSimpleMIRK
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,8 @@
 # SimpleBoundaryValueDiffEq.jl
 
-SimpleBoundaryValueDiffEq.jl provides lightweight boundary value problem
-algorithms for the SciML common solve interface.
+SimpleBoundaryValueDiffEq.jl provides lightweight boundary value problem algorithms for the
+SciML common solve interface. Construct a `BVProblem` or `TwoPointBVProblem` with SciMLBase,
+then select a MIRK collocation method or single-shooting method below.
 
 ## Algorithms
 

--- a/src/SimpleBoundaryValueDiffEq.jl
+++ b/src/SimpleBoundaryValueDiffEq.jl
@@ -1,21 +1,48 @@
 module SimpleBoundaryValueDiffEq
 
-using Reexport: @reexport
 import CommonSolve: solve!
 import DiffEqBase
 import DiffEqBase: solve
 import FiniteDiff
 import SciMLBase
-@reexport using SciMLBase
 using OrdinaryDiffEqTsit5: Tsit5
 using SciMLBase: AbstractBVPAlgorithm, BVProblem, NonlinearFunction, NonlinearProblem,
     ODEProblem, ODESolution, StandardBVProblem, TwoPointBVProblem,
-    build_solution, isinplace
+    build_solution, init, isinplace
 using SimpleNonlinearSolve: SimpleNewtonRaphson
 
-abstract type SimpleBoundaryValueDiffEqAlgorithm <: AbstractBVPAlgorithm end
-abstract type AbstractSimpleMIRK <: SimpleBoundaryValueDiffEqAlgorithm end
-abstract type AbstractSimpleShooting <: SimpleBoundaryValueDiffEqAlgorithm end
+export AbstractSimpleMIRK, SimpleMIRK4, SimpleMIRK5, SimpleMIRK6, SimpleShooting
+export alg_order, alg_stage, constructSimpleMIRK
+
+"""
+    AbstractSimpleMIRK <: AbstractBVPAlgorithm
+
+Developer interface for mono-implicit Runge-Kutta algorithms handled by
+SimpleBoundaryValueDiffEq.jl.
+
+# Interface
+
+To implement a new method, define a concrete subtype and `import`
+[`alg_order`](@ref), [`alg_stage`](@ref), and [`constructSimpleMIRK`](@ref) before extending
+them for that subtype. The generic `solve(prob::BVProblem, alg::AbstractSimpleMIRK; dt)` method
+then constructs and solves the collocation nonlinear problem. Implementations must provide a
+nonlinear solver as the `nlsolve` field or otherwise support `getproperty(alg, :nlsolve)`.
+
+# Required Methods
+
+  - `alg_order(alg) -> Integer`: formal convergence order of `alg`.
+  - `alg_stage(alg) -> Integer`: number of stage derivatives used by `alg`.
+  - `constructSimpleMIRK(alg) -> (c, v, b, x)`: tableau data whose first
+    `alg_stage(alg)` entries and rows describe the stage derivatives. The coefficients must
+    be compatible with arithmetic on the state and time element types accepted by the BVP.
+
+# Usage
+
+See the developer API reference for a minimal subtype and the generic contract test in this
+package for an executable example. This is a developer interface; end users should select one
+of the documented `SimpleMIRK*` algorithms instead of subtyping it.
+"""
+abstract type AbstractSimpleMIRK <: AbstractBVPAlgorithm end
 
 include("utils.jl")
 include("mirk.jl")

--- a/src/mirk.jl
+++ b/src/mirk.jl
@@ -85,9 +85,68 @@ struct SimpleMIRK6{N} <: AbstractSimpleMIRK
 end
 SimpleMIRK6(; nlsolve = SimpleNewtonRaphson()) = SimpleMIRK6(nlsolve)
 
-export SimpleMIRK4
-export SimpleMIRK5
-export SimpleMIRK6
+"""
+    alg_order(alg::AbstractSimpleMIRK) -> Integer
+
+Return the formal convergence order of a developer-defined MIRK algorithm.
+
+# Arguments
+
+  - `alg::AbstractSimpleMIRK`: algorithm whose tableau order is requested.
+
+# Returns
+
+  - `Integer`: the method's formal order.
+
+# Interface
+
+Every concrete subtype of [`AbstractSimpleMIRK`](@ref) must implement this function. The
+result is metadata for users and tests; the generic solver does not infer it from the tableau.
+"""
+function alg_order end
+
+"""
+    alg_stage(alg::AbstractSimpleMIRK) -> Integer
+
+Return the number of stage derivatives used by a developer-defined MIRK algorithm.
+
+# Arguments
+
+  - `alg::AbstractSimpleMIRK`: algorithm whose stage count is requested.
+
+# Returns
+
+  - `Integer`: positive stage count used to allocate and evaluate the collocation stages.
+
+# Interface
+
+Every concrete subtype of [`AbstractSimpleMIRK`](@ref) must implement this function. Its value
+must agree with the leading coefficient entries returned by [`constructSimpleMIRK`](@ref).
+"""
+function alg_stage end
+
+"""
+    constructSimpleMIRK(alg::AbstractSimpleMIRK) -> (c, v, b, x)
+
+Return the collocation tableau used by a developer-defined MIRK algorithm.
+
+# Arguments
+
+  - `alg::AbstractSimpleMIRK`: algorithm whose tableau is requested.
+
+# Returns
+
+  - `(c, v, b, x)`: stage abscissas, interpolation weights, final weights, and strictly
+    lower-triangular stage coupling coefficients.
+
+# Interface
+
+Every concrete subtype of [`AbstractSimpleMIRK`](@ref) must implement this function.
+`c`, `v`, and `b` must have at least `alg_stage(alg)` entries, and `x` must provide the
+corresponding leading square block. Coefficients must support the state and time arithmetic
+performed by the generic MIRK solver.
+"""
+function constructSimpleMIRK end
 
 alg_order(alg::SimpleMIRK4) = 4
 alg_stage(alg::SimpleMIRK4) = 3
@@ -98,6 +157,32 @@ alg_stage(alg::SimpleMIRK5) = 4
 alg_order(alg::SimpleMIRK6) = 6
 alg_stage(alg::SimpleMIRK6) = 5
 
+"""
+    solve(prob::BVProblem, alg::AbstractSimpleMIRK; dt, kwargs...)
+
+Solve a boundary value problem with a mono-implicit Runge-Kutta collocation method.
+
+# Arguments
+
+  - `prob::BVProblem`: in-place or out-of-place boundary value problem to solve.
+  - `alg::AbstractSimpleMIRK`: MIRK algorithm satisfying the documented developer interface.
+
+# Keywords
+
+  - `dt::Real`: positive collocation mesh spacing. This keyword is required in practice;
+    the default sentinel raises an `ArgumentError`.
+  - `kwargs...`: accepted for compatibility with the common solve interface and currently not
+    consumed by this solver.
+
+# Returns
+
+  - `ODESolution`: solution sampled on the collocation mesh with the nonlinear solver's
+    return code.
+
+# Throws
+
+  - `ArgumentError`: if `dt` is not positive.
+"""
 function DiffEqBase.solve(prob::BVProblem, alg::AbstractSimpleMIRK; dt = 0.0, kwargs...)
     dt ≤ 0 && throw(ArgumentError("dt must be positive"))
     N = Int(cld(prob.tspan[2] - prob.tspan[1], dt))

--- a/src/single_shooting.jl
+++ b/src/single_shooting.jl
@@ -27,7 +27,7 @@ using SimpleBoundaryValueDiffEq
 sol = solve(prob, SimpleShooting(); abstol = 1.0e-8, reltol = 1.0e-8)
 ```
 """
-struct SimpleShooting{N, O} <: AbstractSimpleShooting
+struct SimpleShooting{N, O} <: AbstractBVPAlgorithm
     nlsolve::N
     ode_alg::O
 end
@@ -35,8 +35,32 @@ function SimpleShooting(; nlsolve = SimpleNewtonRaphson(), ode_alg = Tsit5())
     return SimpleShooting(nlsolve, ode_alg)
 end
 
-export SimpleShooting
+"""
+    solve(prob::BVProblem, alg::SimpleShooting; abstol = 1.0e-6, reltol = 1.0e-6,
+        odesolve_kwargs = (;), nlsolve_kwargs = (;))
 
+Solve a boundary value problem by integrating an initial value problem and matching its
+boundary residual with a nonlinear solve.
+
+# Arguments
+
+  - `prob::BVProblem`: in-place or out-of-place boundary value problem to solve.
+  - `alg::SimpleShooting`: shooting algorithm that selects the ODE and nonlinear solvers.
+
+# Keywords
+
+  - `abstol::Real = 1.0e-6`: absolute tolerance supplied to both internal solves.
+  - `reltol::Real = 1.0e-6`: relative tolerance supplied to both internal solves.
+  - `odesolve_kwargs::NamedTuple = (;)`: additional keyword arguments forwarded to the ODE
+    solver selected by `alg.ode_alg`.
+  - `nlsolve_kwargs::NamedTuple = (;)`: additional keyword arguments forwarded to the
+    nonlinear solver selected by `alg.nlsolve`.
+
+# Returns
+
+  - `ODESolution`: final ODE trajectory, boundary residual, and return code from the internal
+    solves.
+"""
 function DiffEqBase.solve(
         prob::BVProblem, alg::SimpleShooting; abstol = 1.0e-6,
         reltol = 1.0e-6, odesolve_kwargs = (;), nlsolve_kwargs = (;)
@@ -47,7 +71,7 @@ function DiffEqBase.solve(
     iip = isinplace(prob)
 
     internal_prob = ODEProblem{iip}(prob.f, u0, prob.tspan, prob.p)
-    ode_cache = SciMLBase.__init(
+    ode_cache = init(
         internal_prob, alg.ode_alg; abstol = abstol, reltol = reltol, odesolve_kwargs...
     )
 
@@ -81,7 +105,7 @@ function DiffEqBase.solve(
     nlsol = solve(nlprob, alg.nlsolve, abstol = abstol, reltol = reltol, nlsolve_kwargs...)
 
     internal_prob_final = ODEProblem{iip}(prob.f, nlsol.u, prob.tspan, prob.p)
-    odesol = SciMLBase.__solve(
+    odesol = solve(
         internal_prob_final, alg.ode_alg, abstol = abstol,
         reltol = reltol, odesolve_kwargs...
     )

--- a/test/developer_interfaces.jl
+++ b/test/developer_interfaces.jl
@@ -1,0 +1,40 @@
+using SimpleBoundaryValueDiffEq: AbstractSimpleMIRK
+import SimpleBoundaryValueDiffEq: alg_order, alg_stage, constructSimpleMIRK
+using SciMLBase: BVProblem, solve, successful_retcode
+using SimpleNonlinearSolve: SimpleNewtonRaphson
+using Test
+
+struct MockMIRK{N} <: AbstractSimpleMIRK
+    nlsolve::N
+end
+
+MockMIRK() = MockMIRK(SimpleNewtonRaphson())
+
+alg_order(::MockMIRK) = 4
+alg_stage(::MockMIRK) = 3
+
+function constructSimpleMIRK(::MockMIRK)
+    c = [0, 1, 1 // 2, 3 // 4]
+    v = [0, 1, 1 // 2, 27 // 32]
+    b = [1 // 6, 1 // 6, 2 // 3, 0]
+    x = [
+        0 0 0 0
+        0 0 0 0
+        1 // 8 -1 // 8 0 0
+        3 // 64 -9 // 64 0 0
+    ]
+    return c, v, b, x
+end
+
+@testset "AbstractSimpleMIRK developer interface" begin
+    f(u, p, t) = zero(u)
+    bc(y, p, t) = [y[1][1] - 1]
+    prob = BVProblem(f, bc, [0.0], (0.0, 1.0))
+
+    sol = solve(prob, MockMIRK(); dt = 0.25)
+
+    @test alg_order(MockMIRK()) == 4
+    @test alg_stage(MockMIRK()) == 3
+    @test successful_retcode(sol)
+    @test sol.u[end][1] ≈ 1.0
+end

--- a/test/nopre/Project.toml
+++ b/test/nopre/Project.toml
@@ -5,11 +5,8 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SimpleBoundaryValueDiffEq = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SimpleBoundaryValueDiffEq = { path = "../.." }
-
 [compat]
 JET = "0.9.9, 0.10, 0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,15 +1,7 @@
 [deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SimpleBoundaryValueDiffEq = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Aqua = "0.8"
-JET = "0.9.9, 0.10, 0.11"
-SafeTestsets = "0.1, 1"
-SciMLTesting = "2.1"
-Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,3 @@
-using SciMLTesting, SimpleBoundaryValueDiffEq, JET
+using SciMLTesting, SimpleBoundaryValueDiffEq
 
 run_qa(SimpleBoundaryValueDiffEq)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,9 @@ run_tests(;
         @testset "Test Shooting methods convergence" begin
             include(joinpath(@__DIR__, "shooting_tests.jl"))
         end
+        @testset "Developer interfaces" begin
+            include(joinpath(@__DIR__, "developer_interfaces.jl"))
+        end
     end,
     qa = () -> begin
         activate_group_env(joinpath(@__DIR__, "qa"))

--- a/test/shooting_tests.jl
+++ b/test/shooting_tests.jl
@@ -1,4 +1,5 @@
 using SimpleBoundaryValueDiffEq, LinearAlgebra, Test
+using SciMLBase: BVProblem, TwoPointBVProblem, solve, successful_retcode
 
 tspan = (0.0, 100.0)
 u0 = [0.0, 1.0]
@@ -45,6 +46,6 @@ bvp4 = TwoPointBVProblem(f1, (bc2a, bc2b), u0, tspan)
 
 for prob in (bvp1, bvp2, bvp3, bvp4)
     sol = solve(prob, SimpleShooting(), abstol = 1.0e-8, reltol = 1.0e-8)
-    @test SciMLBase.successful_retcode(sol)
+    @test successful_retcode(sol)
     @test norm(sol.resid, Inf) < 1.0e-8
 end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- migrate all QA groups to the strict SciMLTesting 2.4 defaults with a plain `run_qa(SimpleBoundaryValueDiffEq)` entrypoint
- remove the blanket SciMLBase reexport and bump the package to 2.0.0
- document the public MIRK developer contract, render it in the docs, and test a generic external mock implementation
- use public SciMLBase `init` and `solve` APIs for shooting

## Validation
- Julia 1.12 `Pkg.test()`: Aqua 9/9, MIRK 15/15, shooting 8/8, developer interfaces 4/4, JET 1/1
- strict QA: 20/20
- Documenter doctests, export checkdocs, cross references, and HTML rendering
- Runic and `git diff --check`