### PR TITLE
Raise Aqua floor and ignore Aqua in stale_deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 
 [compat]
-Aqua = "0.8"
+Aqua = "0.8.11"
 BVProblemLibrary = "0.1.5"
 CommonSolve = "0.2"
 DiffEqBase = "7"

--- a/test/aqua_tests.jl
+++ b/test/aqua_tests.jl
@@ -7,7 +7,7 @@
     Aqua.test_ambiguities(SimpleBoundaryValueDiffEq; recursive = false)
     Aqua.test_deps_compat(SimpleBoundaryValueDiffEq)
     Aqua.test_project_extras(SimpleBoundaryValueDiffEq)
-    Aqua.test_stale_deps(SimpleBoundaryValueDiffEq; ignore = [:TimerOutputs])
+    Aqua.test_stale_deps(SimpleBoundaryValueDiffEq; ignore = [:TimerOutputs, :Aqua])
     Aqua.test_unbound_args(SimpleBoundaryValueDiffEq)
     Aqua.test_undefined_exports(SimpleBoundaryValueDiffEq)
 end


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

- `Aqua` `[compat]` `0.8` → `0.8.11`
- `test/aqua_tests.jl`: `Aqua.test_stale_deps` ignore list now includes `:Aqua`

No package version change.

## Why

Default-branch Downgrade is red while Tests are green ([run](https://github.com/SciML/SimpleBoundaryValueDiffEq.jl/actions/runs/31869443706)). Downgrade pins `Aqua 0.8.0`, which reports Aqua itself as a stale extra. The error text says to pass the package name to `ignore`. Tests stay green on newer Aqua; this matches that and stops 0.8.0 from failing Core.

## Verification

CI fail-before: `Aqua.test_stale_deps` failed listing `Aqua [4c88cf16-...]`.

Not verified here: the full test suite or a live `julia-downgrade-compat` run.
