### PR TITLE
Run Aqua checks in the QA group

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,9 +9,6 @@ const GROUP = current_group()
 
 run_tests(;
     core = () -> begin
-        @testset "Code quality (Aqua.jl)" begin
-            include(joinpath(@__DIR__, "aqua_tests.jl"))
-        end
         @testset "Test MIRK methods convergence" begin
             include(joinpath(@__DIR__, "mirk_tests.jl"))
         end
@@ -24,6 +21,9 @@ run_tests(;
     end,
     qa = () -> begin
         activate_group_env(joinpath(@__DIR__, "qa"))
+        @testset "Code quality (Aqua.jl)" begin
+            include(joinpath(@__DIR__, "aqua_tests.jl"))
+        end
         include(joinpath(@__DIR__, "qa", "qa.jl"))
     end,
     groups = Dict(


### PR DESCRIPTION
Run SimpleBoundaryValueDiffEq's Aqua checks in the existing QA test group instead of the downgraded Core group.

DowngradeCI promotes old-style test extras into `[deps]` so their minimum versions remain locked through `Pkg.test`. Aqua then correctly sees those test-only packages as stale runtime dependencies while the temporary metadata is active. The functional Core tests should still run against the minimum graph; the QA group runs after the shared workflow restores the package metadata.

Verification on Julia 1.10:

- Before, the exact minimum-resolved base branch failed the locked test with Aqua: 8 passed, 1 failed; the stale list contained `DiffEqDevTools`, `SciMLTesting`, `BVProblemLibrary`, and `SafeTestsets`.
- After, the same minimum resolution passed. `GROUP=Core` passed 15 MIRK, 8 shooting, and 4 developer-interface tests. `GROUP=QA` passed Aqua 9/9 and Quality Assurance 18/18.
- `git diff --check origin/main...HEAD` passed.

This moves an existing check between test groups; no checks are removed or ignored. No public API is changed, so no deprecation path is required.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.
