### PR TITLE
docs: remove warnonly override

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,5 +4,5 @@ SimpleBoundaryValueDiffEq = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
 
 [compat]
 Documenter = "1"
-SimpleBoundaryValueDiffEq = "2"
+SimpleBoundaryValueDiffEq = "1"
 julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,5 +21,4 @@ makedocs(;
         "Developer API" => "developer_api.md",
     ],
     checkdocs = :exports,
-    warnonly = false,
 )


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed

- Remove the repository-level `warnonly = false` override; Documenter now uses its standard strict behavior.
- Correct the existing docs environment compatibility entry from `SimpleBoundaryValueDiffEq = "2"` to `"1"`, matching the current package version `1.5.0` so the docs environment resolves.
- Preserve `checkdocs = :exports`, the rendered public API manual, and doctests.

## Verification

- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`
  - Aqua `9/9`; Quality Assurance `20/20`; `Testing SimpleBoundaryValueDiffEq tests passed`.
- `julia --startup-file=no --project=docs -e 'using Pkg; Pkg.instantiate()' && julia --startup-file=no --project=docs docs/make.jl`
  - Passed through `HTMLWriter: rendering HTML pages`.
- `julia --startup-file=no -e 'using Runic; Runic.main(["--check", "docs/make.jl"])'` passed.
- `typos docs/make.jl docs/Project.toml` passed.
- `git diff --check` passed.

Before this change, the docs environment could not be developed locally because the current package is `1.5.0` while `docs/Project.toml` required version `2`; this PR fixes that metadata mismatch without changing package code or API.
